### PR TITLE
fix(details): prevent crash from unguarded SheetState.requireOffset() read

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/ishubhamsingh/splashy/features/details/ui/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/ishubhamsingh/splashy/features/details/ui/DetailsScreen.kt
@@ -213,12 +213,18 @@ data class DetailsScreen(
       },
       sheetShadowElevation = 16.dp,
     ) {
+      // requireOffset() throws until the sheet's AnchoredDraggableState has completed its first
+      // layout pass (e.g. the very first composition), so guard the read and fall back to full
+      // height until a real offset is available.
+      val sheetOffset =
+        runCatching { bottomSheetScaffoldState.bottomSheetState.requireOffset() }.getOrNull()
       Box(
         modifier =
           Modifier.fillMaxWidth()
             .fillMaxHeight(
-              ((bottomSheetScaffoldState.bottomSheetState.requireOffset() + 130) / (heightPixels))
-                .let { if (it == 0f) 1f else it }
+              sheetOffset
+                ?.let { offset -> ((offset + 130) / heightPixels).let { if (it == 0f) 1f else it } }
+                ?: 1f
             )
       ) {
         PhotoContainer(photo = photo, color = color, url = url, altDescription = altDescription)

--- a/composeApp/src/commonMain/kotlin/dev/ishubhamsingh/splashy/features/details/ui/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/ishubhamsingh/splashy/features/details/ui/DetailsScreen.kt
@@ -222,8 +222,9 @@ data class DetailsScreen(
         modifier =
           Modifier.fillMaxWidth()
             .fillMaxHeight(
-              sheetOffset
-                ?.let { offset -> ((offset + 130) / heightPixels).let { if (it == 0f) 1f else it } }
+              sheetOffset?.let { offset ->
+                ((offset + 130) / heightPixels).let { if (it == 0f) 1f else it }
+              }
                 ?: 1f
             )
       ) {


### PR DESCRIPTION
## Summary
- Fixes a `FATAL EXCEPTION` crash on entering the Details screen: `IllegalStateException: The offset was read before being initialized`
- `SheetState.requireOffset()` throws until the bottom sheet's `AnchoredDraggableState` has completed its first layout pass. `DetailsScreen.Content()` was calling it directly inside the `BottomSheetScaffold` content lambda, which runs during composition — before that first layout pass has necessarily happened, so it could throw on first entry to the screen.
- Wrapped the read in `runCatching`, falling back to the same full-height (`1f`) behavior already used for the `it == 0f` edge case, until a real offset becomes available. The read still subscribes the composable to future offset changes, so it recomposes correctly once the sheet has laid out.

## Test plan
- [x] Verified the fix resolves the crash by building and opening the Details screen (confirmed by user)
- [ ] Reviewer: sanity-check the bottom sheet's height animation still tracks drag offset correctly once initialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)